### PR TITLE
Jan 26 Ntuplizer Updates

### DIFF
--- a/DeepCoreTraining/test/test_DeepCoreNtuplizer.py
+++ b/DeepCoreTraining/test/test_DeepCoreNtuplizer.py
@@ -13,11 +13,9 @@ process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 
-## process.GlobalTag.globaltag="94X_mc2017_realistic_v10"
-#process.GlobalTag.globaltag = "120X_mcRun3_2021_realistic_v6" ## Updating global tag since we are using run 3 2021 mc
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2023_realistic', '')
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) ) #-1 = tutti (numero edi eventi)
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')# for hichem's DeepCore ntuples
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) ) #-1 = all events
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
@@ -26,29 +24,22 @@ process.source = cms.Source("PoolSource",
 )
 
 process.options = cms.untracked.PSet(
-   allowUnscheduled = cms.untracked.bool(True),
-   numberOfThreads = cms.untracked.uint32(1),
-   numberOfStreams = cms.untracked.uint32(1),
+#   allowUnscheduled = cms.untracked.bool(True),
+#   numberOfThreads = cms.untracked.uint32(1),
+#   numberOfStreams = cms.untracked.uint32(1),
    wantSummary = cms.untracked.bool(True)
 )
 
 process.ntuples = cms.EDProducer('DeepCoreNtuplizer' ,
- ptMin = cms.double(500) ,
- pMin = cms.double(0),
+ ptMin = cms.double(250) ,
+ pMin = cms.double(250),
+ etaWhereBarrelEnds = cms.double(1.8),
  deltaR = cms.double(0.1),
- barrelTrain =cms.bool(True),
- endcapTrain =cms.bool(False),
- fullTrain =cms.bool(False),
-  
  vertices = cms.InputTag("offlinePrimaryVertices"),
- #pixelClusters=cms.InputTag("siPixelClustersPreSplitting"),
- pixelClusters=cms.InputTag("siPixelClusters"),
+ pixelClusters=cms.InputTag("siPixelClustersPreSplitting"),#ntuplizer local reco cluster collection
+ #pixelClusters=cms.InputTag("siPixelClusters"), #standard reco cluster collection
  cores = cms.InputTag("ak4CaloJets"),
- centralMIPCharge = cms.double(18000.0),
- chargeFractionMin = cms.double(2),
  simTracks= cms.InputTag("g4SimHits"),
- simHit= cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
- simHitEC= cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"),
  pixelCPE = cms.string( "PixelCPEGeneric" ),
  PixelDigiSimLinkVector = cms.InputTag("simSiPixelDigis"),
 )
@@ -59,12 +50,10 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
 )
 
 process.TFileService = cms.Service("TFileService",
-    fileName = cms.string("GraphCoreNtuples.root"),
-    closeFileFast = cms.untracked.bool(True)
-  )
+    fileName = cms.string("OctopiNtuples.root"),
+)
   
 process.MessageLogger.cerr.threshold = "Info"
 process.MessageLogger.debugModules = ["ntuples"]
 
 process.p = cms.Path(process.ntuples) 
-# 500 is the goodone (for barel training) #1000 is the tested one, with p cut insted of pt

--- a/DeepCoreTraining/test/test_DeepCoreNtuplizer_crab.py
+++ b/DeepCoreTraining/test/test_DeepCoreNtuplizer_crab.py
@@ -1,41 +1,27 @@
 from CRABClient.UserUtilities import config,getUsernameFromCRIC
 config = config()
 
-config.General.requestName = 'DeepCoreNtuplizerJul11'
+config.General.requestName = 'OctopiNtuplesQCDJan26'
 config.General.workArea = 'crab_projects'
 config.General.transferOutputs = True
 config.General.transferLogs = True
 
 config.JobType.pluginName = 'Analysis'
-##config.JobType.psetName = 'NNClustSeedInputSimHit_config.py'
-config.JobType.psetName = 'test_DeepCoreNtuplizer.py' ## correct python file
-config.JobType.numCores=8
-config.JobType.maxMemoryMB=20000
+config.JobType.psetName = 'test_DeepCoreNtuplizer.py'
+config.JobType.numCores=1
+config.JobType.maxMemoryMB=2000
 
 
-#config.Data.inputDataset='/store/group/phys_tracking/Soohyuny/DeepCoreNtuplizer/TT_TuneCP5_13p6TeV_powheg-pythia8/DeepCoreNtuplizerInput/'
-config.Data.inputDataset='/TT_TuneCP5_13p6TeV_powheg-pythia8/phys_tracking-DeepCoreNtuplizerInput-be26fda57c0e59b5bf1acceb70010d98/USER'
-## config.Data.inputDataset = '/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/arizzi-TrainJetCoreAll-ddeeece6d9d1848c03a48f0aa2e12852/USER' #barrel input
-## config.Data.inputDataset = '/store/user/hichemb/RelValQCD_Pt_1800_2400_14/DeepCoreNtuplizerInput/211013_194728/0000/output'
-#config.Data.inputDataset = '/RelValQCD_Pt_1800_2400_14/hboucham-DeepCoreNtuplizerInput-6d87375326d3f4c3992ae44982f1a1bf/USER'
-#config.Data.inputDataset = '/RelValQCD_Pt_1800_2400_14/hboucham-DeepCoreNtuplizerInput-e2166fcccba2bba0572671bbca4b6777/USER'
-#config.Data.inputDataset = '/RelValQCD_Pt_1800_2400_14/hboucham-DeepCoreNtuplizerInput-6d87375326d3f4c3992ae44982f1a1bf/USER'
-## config.Data.userInputFiles = ['/eos/uscms/store/user/hichemb/RelValQCD_Pt_1800_2400_14/DeepCoreNtuplizerInput/211013_194728/0000/Ntuplizer_output1.root']
-## config.Data.userInputFiles = ['/eos/uscms/store/user/hichemb/RelValQCD_Pt_1800_2400_14/DeepCoreNtuplizerInput/211013_194728/0000/Ntuplizer_output1.root']
-# config.Data.inputDataset = '/UBGGun_E-1000to7000_Eta-1p2to2p1_13TeV_pythia8/vbertacc-DeepCoreTrainingSampleEC_all-3b4718db5896f716d6af32b678bbc9f2/USER' #endcap input
-config.Data.inputDBS = 'phys03' ##'phys03' ## might need to change to global?
-config.Data.splitting = 'EventAwareLumiBased'
-config.Data.unitsPerJob = 1000
-NJOBS = 5000
-config.Data.totalUnits = config.Data.unitsPerJob * NJOBS
+#config.Data.inputDataset='/TT_TuneCP5_13p6TeV_powheg-pythia8/phys_tracking-DeepCoreNtuplizerInput-be26fda57c0e59b5bf1acceb70010d98/USER'
+config.Data.inputDBS = 'phys03' 
+config.Data.userInputFiles = open('DeepCoreFiles.txt').readlines()
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 5
+NJOBS = 1
+config.Data.totalUnits = -1 #config.Data.unitsPerJob * NJOBS
 
-#config.Data.outLFNDirBase = '/store/user/%s/DeepCoreTrainingSample' % (getUsernameFromCRIC())
 
-config.Data.publication = True
-config.Data.outputDatasetTag = 'DeepCoreTrainingSample'
-##config.Data.totalUnits = config.Data.unitsPerJob*10000
-
-#config.Site.storageSite = "T2_IT_Pisa
-#config.Site.storageSite = "T3_US_FNALLPC"
-config.Site.storageSite = 'T2_CH_CERN'
-config.Data.outLFNDirBase = '/store/group/phys_tracking/Soohyuny/DeepCoreNtuplizer/'
+config.Data.publication = False
+#config.Data.outputDatasetTag = 'OctopiNtuples'
+config.Data.outLFNDirBase = '/store/user/%s/' % (getUsernameFromCRIC())
+config.Site.storageSite = 'T3_US_FNALLPC' 


### PR DESCRIPTION
@joshshterenberg I changed the X and Y coordinates to the conformal versions in the ntuples, and removed the extra simtrack variables and converted the doubles to floats to save space.

Then, I processed the standard DeepCore dataset, high pT (1800-2400 GeV) jets from pure QCD. The dataset (17GB) is hosted on lxplus: `/eos/user/n/nihaubri/OctopiNtuples/QCDJan26`. I guess for now you can just use what fits into memory but we may need to switch to batch loading for full trainings.